### PR TITLE
change X-Google-Upload-File-Name to X-Goog-Upload-File-Name

### DIFF
--- a/src/Google/Photos/Library/V1/PhotosLibraryClient.php
+++ b/src/Google/Photos/Library/V1/PhotosLibraryClient.php
@@ -140,7 +140,7 @@ class PhotosLibraryClient extends PhotosLibraryGapicClient
                 'headers' => [
                     'Content-type' => 'application/octet-stream',
                     'Authorization' => $this->getCredentialsWrapper()->getBearerString(),
-                    'X-Google-Upload-File-Name' => $fileName,
+                    'X-Goog-Upload-File-Name' => $fileName,
                 ],
                 'body' => $rawFile,
                 'timeout' => $this->uploadRetrySettings->retriesEnabled

--- a/tests/Unit/V1/PhotosLibraryClientWrapperTest.php
+++ b/tests/Unit/V1/PhotosLibraryClientWrapperTest.php
@@ -73,7 +73,7 @@ class PhotosLibraryClientWrapperTest extends GeneratedTest
 
         $request = $this->mockHttpHandler->getLastRequest();
         $this->assertSame("application/octet-stream", $request->getHeaderLine('Content-type'));
-        $this->assertSame("my_file.png", $request->getHeaderLine('X-Google-Upload-File-Name'));
+        $this->assertSame("my_file.png", $request->getHeaderLine('X-Goog-Upload-File-Name'));
         $this->assertSame("bearer string", $request->getHeaderLine('Authorization'));
         $this->assertSame("some bytes", (string) $request->getBody());
     }


### PR DESCRIPTION
In the official document (https://developers.google.com/photos/library/guides/upload-media)
filename header is `X-Goog-Upload-File-Name` not `X-Google-Upload-File-Name`