### PR TITLE
Fix bug: Samples is saving access token, not refresh token

### DIFF
--- a/src/common/common.php
+++ b/src/common/common.php
@@ -90,8 +90,7 @@ function connectWithGooglePhotos(array $scopes, $redirectURI)
     } else {
         // With the code returned by the OAuth flow, we can retrieve the refresh token.
         $oauth2->setCode($_GET['code']);
-        $authToken = $oauth2->fetchAuthToken();
-        $refreshToken = $authToken['access_token'];
+        $refreshToken = $oauth2->getRefreshToken();
 
         // The UserRefreshCredentials will use the refresh token to 'refresh' the credentials when
         // they expire.


### PR DESCRIPTION
There is a bug in the sample code that results in the access token being saved as the refresh token, instead of the refresh token being saved.

See the PR for a fix.